### PR TITLE
[0.x] Adding Cache Directive to recommendation query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.2] - 2020-12-09
 ### Added
 - `@cacheControl` directive to `recommendation` query.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `@cacheControl` directive to `recommendation` query.
 
 ## [0.1.0] - 2020-07-31
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -12,7 +12,7 @@ type Query {
     categories: [String]
     userNavigationInfo: UserNavigationInfo
     settings: StoreFrontSettings
-  ): [ApiBasedRecommendation]
+  ): [ApiBasedRecommendation] @cacheControl(scope: SEGMENT)
 }
 
 input UserNavigationInfo {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -12,7 +12,7 @@ type Query {
     categories: [String]
     userNavigationInfo: UserNavigationInfo
     settings: StoreFrontSettings
-  ): [ApiBasedRecommendation] @cacheControl(scope: SEGMENT)
+  ): [ApiBasedRecommendation] @cacheControl(scope: PUBLIC)
 }
 
 input UserNavigationInfo {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "recommendation-shelf",
   "vendor": "vtex",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.2",
   "title": "Recommendation Shelf",
   "description": "Recommendation components and functionality for VTEX IO.",
   "scripts": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "recommendation-shelf",
   "vendor": "vtex",
-  "version": "0.1.0",
+  "version": "0.1.1-beta.0",
   "title": "Recommendation Shelf",
   "description": "Recommendation components and functionality for VTEX IO.",
   "scripts": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "recommendation-shelf",
   "vendor": "vtex",
-  "version": "0.1.1-beta.0",
+  "version": "0.1.2-beta.0",
   "title": "Recommendation Shelf",
   "description": "Recommendation components and functionality for VTEX IO.",
   "scripts": {

--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "prettier": "^1.18.2",
     "tslint": "^5.18.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "scripts": {},
   "author": "",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1597,10 +1597,10 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/react/package.json
+++ b/react/package.json
@@ -17,7 +17,7 @@
     "react": "^16.8.6",
     "react-apollo": "2.4.1",
     "react-dom": "^16.8.6",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2446,10 +2446,10 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
Necessary due to our new fallback option on `vtex.render-runtime`