### PR TITLE
Fix input for secondary strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Input for secondary strategy.
+
 ## [1.2.0] - 2021-01-18
 
 ### Changed

--- a/react/hooks/useRecommendation.tsx
+++ b/react/hooks/useRecommendation.tsx
@@ -32,6 +32,19 @@ function useRecommendation<D = Data>(
     anonymous
   )
 
+  const secondaryInput = useMemo(() => {
+    if (!secondaryStrategy) {
+      return input
+    }
+
+    return buildInputByStrategy(
+      secondaryStrategy,
+      productIds,
+      categories,
+      anonymous
+    )
+  }, [anonymous, categories, input, productIds, secondaryStrategy])
+
   const variables = {
     input: {
       sessionId: sessionId ?? '',
@@ -45,7 +58,7 @@ function useRecommendation<D = Data>(
     input: {
       sessionId: sessionId ?? '',
       strategy: secondaryStrategy ?? '',
-      input,
+      input: secondaryInput,
       recommendation,
     },
   }


### PR DESCRIPTION
#### What problem is this solving?

In some cases, the input for the main strategy needs a product or category id, but the secondary strategy may be a strategy that doesn't need that id. 
In this case, when sending the ids the API will return an error and none of the strategies will work. Therefore, we need to rebuild the input based on the secondary strategy.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://recommendation--exitocol.myvtex.com/limon-tahiti-unidad-956930/p) 

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
