### PR TITLE
Use secondaryStrategy when recommendations array is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Use `secondaryStrategy` when `recommendations` array is empty.
+
+
 ## [1.6.2] - 2022-01-10
 
 ### Fixed

--- a/react/hooks/useRecommendation.tsx
+++ b/react/hooks/useRecommendation.tsx
@@ -70,6 +70,13 @@ function useRecommendation<D = Data>(
     variables,
     notifyOnNetworkStatusChange: true,
     skip: skipQuery,
+    onCompleted: (result: unknown) => {
+      if (
+        !(result as Data)?.recommendation?.response?.recommendations?.length
+      ) {
+        setUseSecondary(!!secondaryStrategy)
+      }
+    },
     onError: () => {
       setUseSecondary(!!secondaryStrategy)
     },


### PR DESCRIPTION
#### What problem is this solving?
when `recommendations` array came empty from API, the secondary strategy wasn't being applied. this was only being applied for error cases.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://observaciones--discoargentina.myvtex.com/)

#### Screenshots or example usage:

Before (shelf didn't appear because the secondary strategy was not being called):
![image](https://user-images.githubusercontent.com/20840671/151185974-4b237298-39cc-4316-a5c2-a9793b2d637d.png)

After:
![image](https://user-images.githubusercontent.com/20840671/151185528-ff179e2a-27a0-4064-a348-e3420c628bff.png)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
