### PR TITLE
Enable Cart Recommendatitons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `itemsContext` prop, now its possible to specify from where we should extract the items passed in the recommendation request.
+
+### Changed
+
+- Passing multiple products in the recommendation request if the itemsContext is `CART`.
+
+### Fixed
+
+- Loading shimmer gaps.
+
 ## [2.11.0] - 2025-08-13
 
 ### Changed

--- a/examples/cart.js
+++ b/examples/cart.js
@@ -1,0 +1,79 @@
+const querySelector = '.checkout-container'
+const workspaceCookie = 'VtexWorkspace'
+const targetWorkspace = 'master'
+
+function getCookie(name) {
+  const regex = new RegExp(`(^|;)[ ]*${name}=([^;]*)`)
+  const match = regex.exec(document.cookie)
+
+  return match ? decodeURIComponent(match[2]) : null
+}
+
+function insertIframeAfterCheckoutContainer() {
+  const container = document.querySelector(querySelector)
+
+  if (!container) return
+
+  const iframeContainer = document.createElement('div')
+
+  iframeContainer.className = 'recommendations-embedded-shelf'
+  iframeContainer.style.width = '100%'
+  iframeContainer.style.height = '750px'
+  iframeContainer.style.overflow = 'hidden'
+
+  const iframe = document.createElement('iframe')
+  // URL defined in the store-theme.
+  const iframeUrl = '/_v/public/recommendations-embedded-shelf/'
+
+  iframe.src = iframeUrl
+  iframe.style.width = '100%'
+  iframe.style.height = '100%'
+  iframe.style.border = 'none'
+  iframe.style.marginTop = '-125px'
+  iframe.scrolling = 'no'
+  iframe.id = 'recommendations-embedded-shelf-iframe'
+
+  // Skip displaying the iframe if the current workspace is not the target workspace. Used for A/B testing
+
+  // const currentWorkspace = getCookie(workspaceCookie)
+  // if (currentWorkspace === null || (currentWorkspace && !currentWorkspace.includes(targetWorkspace))) return
+
+  iframeContainer.appendChild(iframe)
+  container.parentNode.insertBefore(iframeContainer, container.nextSibling)
+
+  setInterval(() => {
+    // Validates if the iframe is on the correct page
+    if (
+      !iframe.contentWindow.location.href.includes(iframeUrl) &&
+      !iframe.contentWindow.location.pathname.endsWith('/p') // it should allow redirects to pdp
+    ) {
+      iframe.contentWindow.location.href =
+      iframe.contentWindow.location.origin + iframeUrl
+    }
+  }, 1000)
+  // Syncronize the iframe url with the parent window to allow some navigations...
+  iframe.contentWindow.navigation.addEventListener(
+    'navigate',
+    function handleIframeNavigate(navigate) {
+      if (!navigate.destination.url.includes(iframeUrl)) {
+        window.location.href = navigate.destination.url
+      }
+
+      if (navigate.destination.url.includes('/checkout/#/cart')) {
+        window.location.reload()
+      }
+    }
+  )
+}
+
+function tryInsertIframe(retries = 100, interval = 75) {
+  const container = document.querySelector(querySelector)
+
+  if (container) {
+    insertIframeAfterCheckoutContainer()
+  } else if (retries > 0) {
+    setTimeout(() => tryInsertIframe(retries - 1, interval), interval)
+  }
+}
+
+window.addEventListener('load', () => tryInsertIframe())

--- a/messages/context.json
+++ b/messages/context.json
@@ -3,5 +3,9 @@
   "admin/editor.recommendation-shelf.description": "Recommendation Shelf is a component that displays a collection of items that are recommended to the user based on various algorithms and context data.",
   "admin/editor.recommendation-shelf.title": "Shelf title",
   "admin/editor.recommendation-shelf.campaign-vrn": "Campaign VRN",
-  "admin/editor.recommendation-shelf.display-title": "Display title"
+  "admin/editor.recommendation-shelf.display-title": "Display title",
+  "admin/editor.recommendation-shelf.items-context": "Items Context",
+  "admin/editor.recommendation-shelf.items-context.description": "From where to retrieve the items that will be used as context in the Recommendation request",
+  "admin/editor.recommendation-shelf.items-context.cart": "Cart",
+  "admin/editor.recommendation-shelf.items-context.pdp": "Product Page"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -3,5 +3,9 @@
   "admin/editor.recommendation-shelf.description": "Recommendation Shelf is a component that displays a collection of items that are recommended to the user based on various algorithms and context data.",
   "admin/editor.recommendation-shelf.title": "Shelf title",
   "admin/editor.recommendation-shelf.campaign-vrn": "Campaign VRN",
-  "admin/editor.recommendation-shelf.display-title": "Display title"
+  "admin/editor.recommendation-shelf.display-title": "Display title",
+  "admin/editor.recommendation-shelf.items-context": "Items Context",
+  "admin/editor.recommendation-shelf.items-context.description": "From where to retrieve the items that will be used as context in the Recommendation request",
+  "admin/editor.recommendation-shelf.items-context.cart": "Cart",
+  "admin/editor.recommendation-shelf.items-context.pdp": "Product Page"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -3,5 +3,9 @@
   "admin/editor.recommendation-shelf.description": "La estantería de recomendaciones es un componente que muestra una colección de artículos recomendados al usuario según varios algoritmos y datos de contexto.",
   "admin/editor.recommendation-shelf.title": "Título de la estantería",
   "admin/editor.recommendation-shelf.campaign-vrn": "Campaña VRN",
-  "admin/editor.recommendation-shelf.display-title": "Mostrar título"
+  "admin/editor.recommendation-shelf.display-title": "Mostrar título",
+  "admin/editor.recommendation-shelf.items-context": "Contexto de los artículos",
+  "admin/editor.recommendation-shelf.items-context.description": "Contexto de los artículos",
+  "admin/editor.recommendation-shelf.items-context.cart": "Carrito",
+  "admin/editor.recommendation-shelf.items-context.pdp": "Página de producto"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -3,5 +3,9 @@
   "admin/editor.recommendation-shelf.description": "A Vitrine de Recomendação é um componente que exibe uma coleção de itens recomendados ao usuário com base em diversos algoritmos e dados de contexto.",
   "admin/editor.recommendation-shelf.title": "Título da Vitrine",
   "admin/editor.recommendation-shelf.campaign-vrn": "VRN da Campanha",
-  "admin/editor.recommendation-shelf.display-title": "Mostrar Título"
+  "admin/editor.recommendation-shelf.display-title": "Mostrar Título",
+  "admin/editor.recommendation-shelf.items-context": "Contexto dos Itens",
+  "admin/editor.recommendation-shelf.items-context.description": "De onde recuperar os itens que serão usados como contexto na requisição de recomendação",
+  "admin/editor.recommendation-shelf.items-context.cart": "Carrinho",
+  "admin/editor.recommendation-shelf.items-context.pdp": "Página de Produto"
 }

--- a/react/RecommendationShelf.tsx
+++ b/react/RecommendationShelf.tsx
@@ -49,7 +49,7 @@ type Props = {
   title?: string
   recommendationType?: RecommendationType // Deprecated, use campaignVrn instead
   displayTitle: boolean
-  itemsContext: Array<'PDP' | 'CART'>
+  itemsContext: ItemContextType[]
 }
 
 const RecommendationShelf: StorefrontFunctionComponent<Props> = ({
@@ -57,6 +57,7 @@ const RecommendationShelf: StorefrontFunctionComponent<Props> = ({
   title,
   recommendationType,
   displayTitle,
+  itemsContext,
 }) => {
   return (
     <RecommendationShelfErrorBoundary>
@@ -65,6 +66,7 @@ const RecommendationShelf: StorefrontFunctionComponent<Props> = ({
         title={title}
         recommendationType={recommendationType}
         displayTitle={displayTitle}
+        itemsContext={itemsContext}
       />
     </RecommendationShelfErrorBoundary>
   )

--- a/react/RecommendationShelf.tsx
+++ b/react/RecommendationShelf.tsx
@@ -26,6 +26,22 @@ defineMessages({
     id: 'admin/editor.recommendation-shelf.display-title',
     defaultMessage: 'Display Title',
   },
+  itemsContext: {
+    id: 'admin/editor.recommendation-shelf.items-context',
+    defaultMessage: 'Items Context',
+  },
+  itemsContextDescription: {
+    id: 'admin/editor.recommendation-shelf.items-context.description',
+    defaultMessage: 'Items Context',
+  },
+  itemsContextCart: {
+    id: 'admin/editor.recommendation-shelf.items-context.cart',
+    defaultMessage: 'Items Context',
+  },
+  itemsContextPdp: {
+    id: 'admin/editor.recommendation-shelf.items-context.pdp',
+    defaultMessage: 'Items Context',
+  },
 })
 
 type Props = {
@@ -33,6 +49,7 @@ type Props = {
   title?: string
   recommendationType?: RecommendationType // Deprecated, use campaignVrn instead
   displayTitle: boolean
+  itemsContext: Array<'PDP' | 'CART'>
 }
 
 const RecommendationShelf: StorefrontFunctionComponent<Props> = ({
@@ -70,6 +87,21 @@ RecommendationShelf.schema = {
       title: 'admin/editor.recommendation-shelf.display-title',
       type: 'boolean',
       default: true,
+    },
+    itemsContext: {
+      title: 'admin/editor.recommendation-shelf.items-context',
+      description:
+        'admin/editor.recommendation-shelf.items-context.description',
+      type: 'array',
+      items: {
+        type: 'string',
+        enum: ['PDP', 'CART'],
+        enumNames: [
+          'admin/editor.recommendation-shelf.items-context.pdp',
+          'admin/editor.recommendation-shelf.items-context.cart',
+        ],
+      },
+      default: ['PDP'],
     },
   },
 }

--- a/react/RecommendationShelf.tsx
+++ b/react/RecommendationShelf.tsx
@@ -32,15 +32,16 @@ defineMessages({
   },
   itemsContextDescription: {
     id: 'admin/editor.recommendation-shelf.items-context.description',
-    defaultMessage: 'Items Context',
+    defaultMessage:
+      'From where to retrieve the items that will be used as context in the Recommendation request',
   },
   itemsContextCart: {
     id: 'admin/editor.recommendation-shelf.items-context.cart',
-    defaultMessage: 'Items Context',
+    defaultMessage: 'Cart',
   },
   itemsContextPdp: {
     id: 'admin/editor.recommendation-shelf.items-context.pdp',
-    defaultMessage: 'Items Context',
+    defaultMessage: 'Product Page',
   },
 })
 

--- a/react/components/RecommendationShelfContainer.tsx
+++ b/react/components/RecommendationShelfContainer.tsx
@@ -11,7 +11,7 @@ import { getWithRetry } from '../utils/getWithRetry'
 import { logger } from '../utils/logger'
 import { ShelfSkeleton } from './ShelfSkeleton'
 
-type ProductContext = 'empty' | 'cart' | 'productPage'
+type ProductContext = 'empty' | 'cross' | 'productPage'
 
 const RecommendationToProductMapping: Record<
   RecommendationType,
@@ -19,7 +19,7 @@ const RecommendationToProductMapping: Record<
 > = {
   SIMILAR_ITEMS: 'productPage',
   PERSONALIZED: 'empty',
-  CROSS_SELL: 'productPage',
+  CROSS_SELL: 'cross',
   LAST_SEEN: 'empty',
   TOP_ITEMS: 'empty',
   VISUAL_SIMILARITY: 'productPage',
@@ -64,11 +64,16 @@ export const RecommendationShelfContainer: React.FC<Props> = ({
     return { campaignType: recommendationType }
   }, [campaignVrn, recommendationType])
 
+  const cartItems: string[] =
+    orderFormItems?.map((item: { productId: string }) => item.productId) ?? []
+
+  const currentProduct = productContext?.product?.productId
+
   const productSource: Record<ProductContext, string[]> = {
-    cart:
-      orderFormItems?.map((item: { productId: string }) => item.productId) ??
-      [],
-    productPage: [productContext?.product?.productId ?? ''],
+    cross: [currentProduct, ...cartItems].filter(Boolean) as string[],
+    productPage: productContext?.product?.productId
+      ? [productContext.product.productId]
+      : [],
     empty: [],
   }
 

--- a/react/components/ShelfSkeleton/index.tsx
+++ b/react/components/ShelfSkeleton/index.tsx
@@ -18,11 +18,15 @@ function checkDevice(): 'DESKTOP' | 'MOBILE' | 'TABLET' {
     return 'TABLET'
   }
 
-  return 'DESKTOP'
+  if (window.innerWidth > 1024) {
+    return 'DESKTOP'
+  }
+
+  return 'MOBILE'
 }
 
 const DEVICE_MAP = {
-  DESKTOP: 4,
+  DESKTOP: 5,
   MOBILE: 2,
   TABLET: 3,
 }

--- a/react/components/ShelfSkeleton/style.css
+++ b/react/components/ShelfSkeleton/style.css
@@ -25,3 +25,7 @@
   background-size: 50% 100%;
   animation: shimmer-anim 1s linear infinite;
 }
+
+.recommendationShelfContainer {
+  gap: 1.5rem;
+}

--- a/react/hooks/useRecommendations.tsx
+++ b/react/hooks/useRecommendations.tsx
@@ -39,7 +39,6 @@ function getRecommendationArguments(
   /* eslint-disable padding-line-between-statements */
   switch (input.recommendationType) {
     case 'VISUAL_SIMILARITY':
-    case 'CROSS_SELL':
     case 'SIMILAR_ITEMS':
       if (products.length === 0) {
         return null
@@ -50,6 +49,16 @@ function getRecommendationArguments(
         products: products[0],
       }
 
+      break
+    case 'CROSS_SELL':
+      if (products.length === 0) {
+        return null
+      }
+      args = {
+        ...args,
+        an: account,
+        products: products.join(';'),
+      }
       break
     default:
       break

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -22,4 +22,6 @@ declare global {
     | 'LAST_SEEN'
     | 'VISUAL_SIMILARITY'
     | 'SEARCH_BASED'
+
+  export type ItemContextType = 'PDP' | 'CART'
 }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -15,6 +15,20 @@
           "title": "admin/editor.recommendation-shelf.display-title",
           "type": "boolean",
           "default": true
+        },
+        "itemsContext": {
+          "title": "admin/editor.recommendation-shelf.items-context",
+          "type": "array",
+          "default": ["PDP"],
+          "items": {
+            "title": "admin/editor.recommendation-shelf.items-context",
+            "type": "string",
+            "enum": ["PDP", "CART"],
+            "enumNames": [
+              "admin/editor.recommendation-shelf.items-context.pdp",
+              "admin/editor.recommendation-shelf.items-context.cart"
+            ]
+          }
         }
       }
     }


### PR DESCRIPTION
#### What problem is this solving?

- Now the RecommendationShelf can extract and pass multiple items in the recommendation request, which is essential for Cart Recommendations.

- Also added an example of customization to be added in the checkout to enable this shenanigan.
- Example of  custommization to be done in the store theme: https://github.com/vtex-apps/search-demo-theme/pull/15

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://felipe--biggy.myvtex.com)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
