### PR TITLE
feat: visual similarity support, drop v1 VRNs and consolidate dependency bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add support to VisualSimilarity campaigns.
+- Add tests for the VRN parsing utils (`isValidVrn` and `getTypeFromVrn`).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add support to VisualSimilarity campaigns.
+
+### Changed
+
+- Bump dependencies from open Dependabot PRs (`form-data`, `minimatch`, `@babel/plugin-transform-modules-systemjs`, `lodash`, `picomatch`, `flatted`).
+
+### Removed
+
+- Remove deprecated `-v1` recommendation VRN types from VRN parsing.
+
 ## [2.20.0] - 2026-06-01
 
 ### Changed

--- a/react/package.json
+++ b/react/package.json
@@ -28,7 +28,7 @@
     "@vtex/test-tools": "^3.4.3",
     "@vtex/tsconfig": "^0.6.0",
     "braces": "^3.0.3",
-    "form-data": "^2.5.4",
+    "form-data": "^2.5.6",
     "js-yaml": "^3.14.2",
     "micromatch": "^4.0.8",
     "node-notifier": "^8.0.1",

--- a/react/utils/vrn.test.ts
+++ b/react/utils/vrn.test.ts
@@ -1,0 +1,76 @@
+import { getTypeFromVrn, isValidVrn } from './vrn'
+
+const buildVrn = (type: string) => `vrn:recommendations:myaccount:${type}:campaign-123`
+
+describe('isValidVrn', () => {
+  const validV2Types = [
+    'rec-cross-v2',
+    'rec-similar-v2',
+    'rec-visual-v2',
+    'rec-persona-v2',
+    'rec-last-v2',
+    'rec-top-items-v2',
+    'rec-search-v2',
+    'rec-next-v2',
+  ]
+
+  it.each(validV2Types)('returns true for a valid v2 VRN (%s)', (type) => {
+    expect(isValidVrn(buildVrn(type))).toBe(true)
+  })
+
+  const deprecatedV1Types = [
+    'rec-cross-v1',
+    'rec-similar-v1',
+    'rec-visual-v1',
+    'rec-persona-v1',
+    'rec-last-v1',
+    'rec-top-items-v1',
+  ]
+
+  it.each(deprecatedV1Types)('returns false for a deprecated v1 VRN (%s)', (type) => {
+    expect(isValidVrn(buildVrn(type))).toBe(false)
+  })
+
+  it('returns false for an unknown campaign type', () => {
+    expect(isValidVrn(buildVrn('rec-unknown-v2'))).toBe(false)
+  })
+
+  it('returns false for a malformed VRN', () => {
+    expect(isValidVrn('not-a-vrn')).toBe(false)
+    expect(isValidVrn('vrn:recommendations:myaccount:rec-cross-v2')).toBe(false)
+    expect(isValidVrn('')).toBe(false)
+  })
+})
+
+describe('getTypeFromVrn', () => {
+  const cases: Array<[string, RecommendationType]> = [
+    ['rec-cross-v2', 'CROSS_SELL'],
+    ['rec-similar-v2', 'SIMILAR_ITEMS'],
+    ['rec-visual-v2', 'VISUAL_SIMILARITY'],
+    ['rec-persona-v2', 'PERSONALIZED'],
+    ['rec-last-v2', 'LAST_SEEN'],
+    ['rec-top-items-v2', 'TOP_ITEMS'],
+    ['rec-search-v2', 'SEARCH_BASED'],
+    ['rec-next-v2', 'NEXT_INTERACTION'],
+  ]
+
+  it.each(cases)('maps %s to %s', (type, expected) => {
+    expect(getTypeFromVrn(buildVrn(type))).toBe(expected)
+  })
+
+  it('maps rec-visual-v2 to VISUAL_SIMILARITY', () => {
+    expect(getTypeFromVrn(buildVrn('rec-visual-v2'))).toBe('VISUAL_SIMILARITY')
+  })
+
+  it('throws for an unknown campaign type', () => {
+    expect(() => getTypeFromVrn(buildVrn('rec-unknown-v2'))).toThrow(
+      'Unknown campaign type: rec-unknown-v2'
+    )
+  })
+
+  it('throws for a deprecated v1 campaign type', () => {
+    expect(() => getTypeFromVrn(buildVrn('rec-cross-v1'))).toThrow(
+      'Unknown campaign type: rec-cross-v1'
+    )
+  })
+})

--- a/react/utils/vrn.test.ts
+++ b/react/utils/vrn.test.ts
@@ -1,6 +1,7 @@
 import { getTypeFromVrn, isValidVrn } from './vrn'
 
-const buildVrn = (type: string) => `vrn:recommendations:myaccount:${type}:campaign-123`
+const buildVrn = (type: string) =>
+  `vrn:recommendations:myaccount:${type}:campaign-123`
 
 describe('isValidVrn', () => {
   const validV2Types = [
@@ -27,9 +28,12 @@ describe('isValidVrn', () => {
     'rec-top-items-v1',
   ]
 
-  it.each(deprecatedV1Types)('returns false for a deprecated v1 VRN (%s)', (type) => {
-    expect(isValidVrn(buildVrn(type))).toBe(false)
-  })
+  it.each(deprecatedV1Types)(
+    'returns false for a deprecated v1 VRN (%s)',
+    (type) => {
+      expect(isValidVrn(buildVrn(type))).toBe(false)
+    }
+  )
 
   it('returns false for an unknown campaign type', () => {
     expect(isValidVrn(buildVrn('rec-unknown-v2'))).toBe(false)

--- a/react/utils/vrn.ts
+++ b/react/utils/vrn.ts
@@ -1,12 +1,6 @@
 /* eslint-disable padding-line-between-statements */
 
 type RecommendationVrnType =
-  | 'rec-cross-v1'
-  | 'rec-similar-v1'
-  | 'rec-visual-v1'
-  | 'rec-persona-v1'
-  | 'rec-last-v1'
-  | 'rec-top-items-v1'
   | 'rec-cross-v2'
   | 'rec-similar-v2'
   | 'rec-visual-v2'
@@ -17,7 +11,7 @@ type RecommendationVrnType =
   | 'rec-next-v2'
 
 const vrnPattern =
-  /^vrn:recommendations:[^:]+:(rec-cross-v1|rec-similar-v1|rec-visual-v1|rec-persona-v1|rec-last-v1|rec-top-items-v1|rec-cross-v2|rec-similar-v2|rec-visual-v2|rec-persona-v2|rec-last-v2|rec-top-items-v2|rec-search-v2|rec-next-v2):[^:]+$/
+  /^vrn:recommendations:[^:]+:(rec-cross-v2|rec-similar-v2|rec-visual-v2|rec-persona-v2|rec-last-v2|rec-top-items-v2|rec-search-v2|rec-next-v2):[^:]+$/
 
 export function isValidVrn(campaignVrn: string): boolean {
   return vrnPattern.test(campaignVrn)
@@ -33,39 +27,33 @@ function parseCampaignVrn(campaignVrn: string) {
   }
 }
 
-// Cross-sell: rec-cross-v1,  rec-cross-v2
-// Similar-items: rec-similar-v1, rec-similar-v2
-// Visual-similarity: rec-visual-v1, rec-visual-v2
-// Personalized: rec-persona-v1, rec-persona-v2
-// Last Seen: rec-last-v1, rec-last-v2
-// Top items: rec-top-items-v1, rec-top-items-v2
+// Cross-sell: rec-cross-v2
+// Similar-items: rec-similar-v2
+// Visual-similarity: rec-visual-v2
+// Personalized: rec-persona-v2
+// Last Seen: rec-last-v2
+// Top items: rec-top-items-v2
 // Search-based: rec-search-v2
 // Next interactions: rec-next-v2
 export function getTypeFromVrn(campaignVrn: string): RecommendationType {
   const { campaignVrnType } = parseCampaignVrn(campaignVrn)
 
   switch (campaignVrnType) {
-    case 'rec-cross-v1':
     case 'rec-cross-v2':
       return 'CROSS_SELL'
 
-    case 'rec-similar-v1':
     case 'rec-similar-v2':
       return 'SIMILAR_ITEMS'
 
-    case 'rec-visual-v1':
     case 'rec-visual-v2':
       return 'VISUAL_SIMILARITY'
 
-    case 'rec-persona-v1':
     case 'rec-persona-v2':
       return 'PERSONALIZED'
 
-    case 'rec-last-v1':
     case 'rec-last-v2':
       return 'LAST_SEEN'
 
-    case 'rec-top-items-v1':
     case 'rec-top-items-v2':
       return 'TOP_ITEMS'
 

--- a/react/utils/vrn.ts
+++ b/react/utils/vrn.ts
@@ -3,11 +3,13 @@
 type RecommendationVrnType =
   | 'rec-cross-v1'
   | 'rec-similar-v1'
+  | 'rec-visual-v1'
   | 'rec-persona-v1'
   | 'rec-last-v1'
   | 'rec-top-items-v1'
   | 'rec-cross-v2'
   | 'rec-similar-v2'
+  | 'rec-visual-v2'
   | 'rec-persona-v2'
   | 'rec-last-v2'
   | 'rec-top-items-v2'
@@ -15,7 +17,7 @@ type RecommendationVrnType =
   | 'rec-next-v2'
 
 const vrnPattern =
-  /^vrn:recommendations:[^:]+:(rec-cross-v1|rec-similar-v1|rec-persona-v1|rec-last-v1|rec-top-items-v1|rec-cross-v2|rec-similar-v2|rec-persona-v2|rec-last-v2|rec-top-items-v2|rec-search-v2|rec-next-v2):[^:]+$/
+  /^vrn:recommendations:[^:]+:(rec-cross-v1|rec-similar-v1|rec-visual-v1|rec-persona-v1|rec-last-v1|rec-top-items-v1|rec-cross-v2|rec-similar-v2|rec-visual-v2|rec-persona-v2|rec-last-v2|rec-top-items-v2|rec-search-v2|rec-next-v2):[^:]+$/
 
 export function isValidVrn(campaignVrn: string): boolean {
   return vrnPattern.test(campaignVrn)
@@ -33,6 +35,7 @@ function parseCampaignVrn(campaignVrn: string) {
 
 // Cross-sell: rec-cross-v1,  rec-cross-v2
 // Similar-items: rec-similar-v1, rec-similar-v2
+// Visual-similarity: rec-visual-v1, rec-visual-v2
 // Personalized: rec-persona-v1, rec-persona-v2
 // Last Seen: rec-last-v1, rec-last-v2
 // Top items: rec-top-items-v1, rec-top-items-v2
@@ -49,6 +52,10 @@ export function getTypeFromVrn(campaignVrn: string): RecommendationType {
     case 'rec-similar-v1':
     case 'rec-similar-v2':
       return 'SIMILAR_ITEMS'
+
+    case 'rec-visual-v1':
+    case 'rec-visual-v2':
+      return 'VISUAL_SIMILARITY'
 
     case 'rec-persona-v1':
     case 'rec-persona-v2':

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -3920,9 +3920,9 @@ min-indent@^1.0.0:
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 minimatch@^3.0.4, minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4206,9 +4206,9 @@ picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pirates@^4.0.1:
   version "4.0.7"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -2655,15 +2655,15 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
 
-form-data@^2.5.4:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.5.tgz#a5f6364ad7e4e67e95b4a07e2d8c6f711c74f624"
-  integrity sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==
+form-data@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.6.tgz#ef39b3d99e2fc9f25420c0db7962fe36cafcd244"
+  integrity sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
+    hasown "^2.0.4"
     mime-types "^2.1.35"
     safe-buffer "^5.2.1"
 
@@ -2880,10 +2880,10 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-hasown@^2.0.0, hasown@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
-  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+hasown@^2.0.0, hasown@^2.0.2, hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -3797,9 +3797,9 @@ lodash.sortby@^4.7.0:
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
 
 lodash@^4.17.15, lodash@^4.17.19:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 lolex@^5.0.0:
   version "5.1.2"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -73,6 +73,15 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
+"@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
+  integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.28.5"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.27.2":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.27.3.tgz#cc49c2ac222d69b889bf34c795f537c0c6311111"
@@ -108,6 +117,17 @@
     "@babel/types" "^7.27.3"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
+    jsesc "^3.0.2"
+
+"@babel/generator@^7.29.0":
+  version "7.29.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.1.tgz#d09876290111abbb00ef962a7b83a5307fba0d50"
+  integrity sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==
+  dependencies:
+    "@babel/parser" "^7.29.0"
+    "@babel/types" "^7.29.0"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
 
 "@babel/helper-annotate-as-pure@^7.27.1":
@@ -161,6 +181,11 @@
     lodash.debounce "^4.0.8"
     resolve "^1.14.2"
 
+"@babel/helper-globals@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz#b9430df2aa4e17bc28665eadeae8aa1d985e6674"
+  integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
+
 "@babel/helper-member-expression-to-functions@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz#ea1211276be93e798ce19037da6f06fbb994fa44"
@@ -177,6 +202,14 @@
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
 
+"@babel/helper-module-imports@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz#60632cbd6ffb70b22823187201116762a03e2d5c"
+  integrity sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==
+  dependencies:
+    "@babel/traverse" "^7.28.6"
+    "@babel/types" "^7.28.6"
+
 "@babel/helper-module-transforms@^7.27.1", "@babel/helper-module-transforms@^7.27.3":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz#db0bbcfba5802f9ef7870705a7ef8788508ede02"
@@ -185,6 +218,15 @@
     "@babel/helper-module-imports" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
     "@babel/traverse" "^7.27.3"
+
+"@babel/helper-module-transforms@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz#9312d9d9e56edc35aeb6e95c25d4106b50b9eb1e"
+  integrity sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.28.6"
+    "@babel/helper-validator-identifier" "^7.28.5"
+    "@babel/traverse" "^7.28.6"
 
 "@babel/helper-optimise-call-expression@^7.27.1":
   version "7.27.1"
@@ -197,6 +239,11 @@
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz#ddb2f876534ff8013e6c2b299bf4d39b3c51d44c"
   integrity sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==
+
+"@babel/helper-plugin-utils@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz#6f13ea251b68c8532e985fd532f28741a8af9ac8"
+  integrity sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==
 
 "@babel/helper-remap-async-to-generator@^7.27.1":
   version "7.27.1"
@@ -234,6 +281,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
   integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
 
+"@babel/helper-validator-identifier@^7.28.5":
+  version "7.28.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
+  integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
+
 "@babel/helper-validator-option@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz#fa52f5b1e7db1ab049445b421c4471303897702f"
@@ -262,6 +314,13 @@
   integrity sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==
   dependencies:
     "@babel/types" "^7.27.3"
+
+"@babel/parser@^7.28.6", "@babel/parser@^7.29.0":
+  version "7.29.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.3.tgz#116f70a77958307fceac27747573032f8a62f88e"
+  integrity sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==
+  dependencies:
+    "@babel/types" "^7.29.0"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.27.1":
   version "7.27.1"
@@ -616,14 +675,14 @@
     "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-transform-modules-systemjs@^7.27.1":
-  version "7.27.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz#00e05b61863070d0f3292a00126c16c0e024c4ed"
-  integrity sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==
+  version "7.29.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz#f621105da99919c15cf4bde6fcc7346ef95e7b20"
+  integrity sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==
   dependencies:
-    "@babel/helper-module-transforms" "^7.27.1"
-    "@babel/helper-plugin-utils" "^7.27.1"
-    "@babel/helper-validator-identifier" "^7.27.1"
-    "@babel/traverse" "^7.27.1"
+    "@babel/helper-module-transforms" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
+    "@babel/helper-validator-identifier" "^7.28.5"
+    "@babel/traverse" "^7.29.0"
 
 "@babel/plugin-transform-modules-umd@^7.27.1":
   version "7.27.1"
@@ -999,6 +1058,15 @@
     "@babel/parser" "^7.27.2"
     "@babel/types" "^7.27.1"
 
+"@babel/template@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.28.6.tgz#0e7e56ecedb78aeef66ce7972b082fce76a23e57"
+  integrity sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==
+  dependencies:
+    "@babel/code-frame" "^7.28.6"
+    "@babel/parser" "^7.28.6"
+    "@babel/types" "^7.28.6"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.16.0", "@babel/traverse@^7.27.1", "@babel/traverse@^7.27.3":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.27.3.tgz#8b62a6c2d10f9d921ba7339c90074708509cffae"
@@ -1012,6 +1080,19 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
+"@babel/traverse@^7.28.6", "@babel/traverse@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.0.tgz#f323d05001440253eead3c9c858adbe00b90310a"
+  integrity sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==
+  dependencies:
+    "@babel/code-frame" "^7.29.0"
+    "@babel/generator" "^7.29.0"
+    "@babel/helper-globals" "^7.28.0"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.29.0"
+    debug "^4.3.1"
+
 "@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.3.tgz#c0257bedf33aad6aad1f406d35c44758321eb3ec"
@@ -1019,6 +1100,14 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
+
+"@babel/types@^7.28.6", "@babel/types@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
+  integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.28.5"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -1287,6 +1376,14 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
+"@jridgewell/gen-mapping@^0.3.12":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
+  integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz#4f0e06362e01362f823d348f1872b08f666d8142"
@@ -1311,10 +1408,23 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
+"@jridgewell/sourcemap-codec@^1.5.0":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
 "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.28":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1244,9 +1244,9 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.2.9:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
-  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1883,9 +1883,9 @@ lodash.merge@^4.6.2:
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash@^4.17.21:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.0.0:
   version "4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,9 +2154,9 @@ picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pkg-dir@^5.0.0:
   version "5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,9 +1941,9 @@ mimic-fn@^2.1.0:
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 


### PR DESCRIPTION
## Summary
- Add `rec-visual-v2` VRN support in `react/utils/vrn.ts`, mapping it to the `VISUAL_SIMILARITY` recommendation type (matching `recommend-bff`).
- Remove all deprecated `-v1` recommendation VRN types (`rec-cross-v1`, `rec-similar-v1`, `rec-persona-v1`, `rec-last-v1`, `rec-top-items-v1`) from the union type, validation regex and `getTypeFromVrn` switch.
- Consolidate all open Dependabot dependency bumps into this PR (root and `/react` lockfiles).
- Add a `CHANGELOG.md` entry under `[Unreleased]`.

## Consolidated dependency bumps
- `form-data` 2.5.5 → 2.5.6 (`/react`) — #134
- `minimatch` 3.1.2 → 3.1.5 (root) — #132
- `@babel/plugin-transform-modules-systemjs` 7.27.1 → 7.29.4 (`/react`) — #129
- `lodash` 4.17.23 → 4.18.1 (root) — #128
- `lodash` 4.17.23 → 4.18.1 (`/react`) — #127
- `picomatch` 2.3.1 → 2.3.2 (root) — #126
- `picomatch` 2.3.1 → 2.3.2 (`/react`) — #125
- `flatted` 3.3.3 → 3.4.2 (root) — #124
- `minimatch` 3.1.2 → 3.1.5 (`/react`) — #123

## Context
`VISUAL_SIMILARITY` was already declared in `react/typings/global.d.ts` and handled in `react/hooks/useRecommendations.tsx`, but `getTypeFromVrn` did not recognize the visual similarity VRN and would throw `Unknown campaign type` for `rec-visual-v2`. The `-v1` VRN variants are deprecated and were removed.

## Test plan
- [ ] `isValidVrn('vrn:recommendations:<account>:rec-visual-v2:<id>')` returns `true`
- [ ] `getTypeFromVrn` returns `VISUAL_SIMILARITY` for `rec-visual-v2`
- [ ] `isValidVrn` returns `false` for any `-v1` VRN
- [ ] Remaining v2 VRN types keep resolving correctly
- [ ] `yarn install` succeeds with the updated lockfiles (root and `/react`)