### PR TITLE
fix: prevent skeleton shimmer overflow and add responsive sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Skeleton shimmer animation overflow that produced a horizontal scrollbar.
+
+### Changed
+
+- Responsive skeleton piece sizing on screens 1024px and smaller.
+
 ## [2.22.0] - 2026-07-13
 
 ### Added

--- a/react/components/ShelfSkeleton/style.css
+++ b/react/components/ShelfSkeleton/style.css
@@ -11,6 +11,14 @@
 .recommendationSkeletonPiece {
   height: 550px;
   width: 300px;
+  overflow: hidden;
+}
+
+@media screen and (max-width: 1024px) {
+  .recommendationSkeletonPiece {
+    width: 178px;
+    height: 392px;
+  }
 }
 
 .recommendationSkeletonPieceShimmer {


### PR DESCRIPTION
## Summary
- Add `overflow: hidden` to `.recommendationSkeletonPiece` so the shimmer animation (which translates 50% of its width) no longer overflows and produces a horizontal scrollbar.
- Add a `max-width: 1024px` media query to shrink the skeleton piece to `178px × 392px` on smaller screens like phones.

## Test plan
- [ ] Load a page where the recommendation shelf skeleton renders and confirm no horizontal scrollbar appears during the shimmer animation.
- [ ] Resize the viewport to ≤ 1024px and confirm the skeleton piece uses the smaller dimensions.

Made with [Cursor](https://cursor.com)