### PR TITLE
chore: remove skeleton shimmer animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Skeleton shimmer animation to reduce rendering cost, keeping the static gray placeholder.
+
 ## [2.22.1] - 2026-07-17
 
 ### Fixed

--- a/react/components/ShelfSkeleton/SkeletonPiece.tsx
+++ b/react/components/ShelfSkeleton/SkeletonPiece.tsx
@@ -3,10 +3,7 @@ import './style.css'
 import React from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 
-const CSS_HANDLES = [
-  'recommendationSkeletonPiece',
-  'recommendationSkeletonPieceShimmer',
-]
+const CSS_HANDLES = ['recommendationSkeletonPiece']
 
 export function SkeletonPiece() {
   const handles = useCssHandles(CSS_HANDLES)
@@ -14,8 +11,6 @@ export function SkeletonPiece() {
   return (
     <div
       className={`${handles.recommendationSkeletonPiece} bg-muted-4 br3 center`}
-    >
-      <div className={`${handles.recommendationSkeletonPieceShimmer}`} />
-    </div>
+    />
   )
 }

--- a/react/components/ShelfSkeleton/style.css
+++ b/react/components/ShelfSkeleton/style.css
@@ -1,17 +1,6 @@
-/* Skeleton animation */
-@keyframes shimmer-anim {
-  0% {
-    transform: translate3d(0, 0, 0);
-  }
-  100% {
-    transform: translate3d(50%, 0, 0);
-  }
-}
-
 .recommendationSkeletonPiece {
   height: 550px;
   width: 300px;
-  overflow: hidden;
 }
 
 @media screen and (max-width: 1024px) {
@@ -19,19 +8,6 @@
     width: 178px;
     height: 392px;
   }
-}
-
-.recommendationSkeletonPieceShimmer {
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    90deg,
-    rgba(255, 255, 255, 0),
-    rgba(255, 255, 255, 0.30),
-    rgba(255, 255, 255, 0)
-  );
-  background-size: 50% 100%;
-  animation: shimmer-anim 1s linear infinite;
 }
 
 .recommendationShelfContainer {


### PR DESCRIPTION
## Summary
- Remove the animated shimmer overlay (`.recommendationSkeletonPieceShimmer`) and its `@keyframes shimmer-anim` to reduce rendering cost.
- Keep the static gray skeleton placeholder (`bg-muted-4`) and the responsive sizing.

## Test plan
- [ ] Load a page where the recommendation shelf skeleton renders and confirm the gray placeholder shows without any shimmer animation.
- [ ] Confirm no horizontal scrollbar appears and responsive sizing still applies at ≤ 1024px.

Made with [Cursor](https://cursor.com)