### PR TITLE
feat: customizable loading placeholders and stable recommendation args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `displayLoading` prop to toggle whether the loading placeholder is rendered while the shelf loads.
+- `loadingItemsPerPage` prop to customize the number of loading placeholders per device type (`desktop`, `tablet`, `phone`), replacing the previously hardcoded device map.
+
 ### Fixed
 
 - React "state update on a component that hasn't mounted yet" warning by moving the asynchronous userId retrieval from the render body into a `useEffect` with an unmount guard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- React "state update on a component that hasn't mounted yet" warning by moving the asynchronous userId retrieval from the render body into a `useEffect` with an unmount guard.
+
 ## [2.22.2] - 2026-07-20
 
 ### Removed

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,16 @@ Configure the `recommendation-shelf` block using the following properties:
 | `displayTitle` | `boolean` | Whether to show the shelf title (`true`) or hide it (`false`). | `true` |
 | `itemsContext` | `array` | Context source for items in the recommendation request (`PDP` or `CART`). Useful for enabling shelves on the cart page with `CROSS_SELL`. | `['PDP']` |
 | `hiddenPaths` | `array` | URL paths where the shelf should not be displayed. Supports exact paths (e.g. `/checkout/cart`) and prefix wildcards with `*` (e.g. `/produto/*`). Useful when the shelf is placed in a global section (such as the footer) but should be hidden on specific pages. | `[]` |
+| `displayLoading` | `boolean` | Whether to display a loading placeholder while the shelf is loading (`true`) or render nothing until it is ready (`false`). | `true` |
+| `loadingItemsPerPage` | `object` | The number of loading placeholders to display per device type while loading. See the [`loadingItemsPerPage` object](#loadingitemsperpage-object) section below. | `{ desktop: 5, tablet: 3, phone: 2 }` |
+
+#### `loadingItemsPerPage` object
+
+| Prop name | Type | Description | Default value |
+| - | - | - | - |
+| `desktop` | `number` | Number of loading placeholders shown on desktop devices. | `5` |
+| `tablet` | `number` | Number of loading placeholders shown on tablet devices. | `3` |
+| `phone` | `number` | Number of loading placeholders shown on phone devices. | `2` |
 
 ### Obtaining the VRN
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -9,5 +9,12 @@
   "admin/editor.recommendation-shelf.items-context.cart": "Cart",
   "admin/editor.recommendation-shelf.items-context.pdp": "Product Page",
   "admin/editor.recommendation-shelf.hidden-paths": "Hidden paths",
-  "admin/editor.recommendation-shelf.hidden-paths.description": "URL paths where the shelf should not be displayed. Use exact paths (e.g. /checkout/cart) or prefix wildcards with * (e.g. /produto/*)."
+  "admin/editor.recommendation-shelf.hidden-paths.description": "URL paths where the shelf should not be displayed. Use exact paths (e.g. /checkout/cart) or prefix wildcards with * (e.g. /produto/*).",
+  "admin/editor.recommendation-shelf.display-loading": "Display loading",
+  "admin/editor.recommendation-shelf.display-loading.description": "Whether to display a loading placeholder while the shelf is loading.",
+  "admin/editor.recommendation-shelf.loading-items-per-page": "Loading items per page",
+  "admin/editor.recommendation-shelf.loading-items-per-page.description": "The number of loading placeholders to display per device type while loading.",
+  "admin/editor.recommendation-shelf.loading-items-per-page.desktop": "Desktop",
+  "admin/editor.recommendation-shelf.loading-items-per-page.tablet": "Tablet",
+  "admin/editor.recommendation-shelf.loading-items-per-page.phone": "Phone"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,5 +9,12 @@
   "admin/editor.recommendation-shelf.items-context.cart": "Cart",
   "admin/editor.recommendation-shelf.items-context.pdp": "Product Page",
   "admin/editor.recommendation-shelf.hidden-paths": "Hidden paths",
-  "admin/editor.recommendation-shelf.hidden-paths.description": "URL paths where the shelf should not be displayed. Use exact paths (e.g. /checkout/cart) or prefix wildcards with * (e.g. /produto/*)."
+  "admin/editor.recommendation-shelf.hidden-paths.description": "URL paths where the shelf should not be displayed. Use exact paths (e.g. /checkout/cart) or prefix wildcards with * (e.g. /produto/*).",
+  "admin/editor.recommendation-shelf.display-loading": "Display loading",
+  "admin/editor.recommendation-shelf.display-loading.description": "Whether to display a loading placeholder while the shelf is loading.",
+  "admin/editor.recommendation-shelf.loading-items-per-page": "Loading items per page",
+  "admin/editor.recommendation-shelf.loading-items-per-page.description": "The number of loading placeholders to display per device type while loading.",
+  "admin/editor.recommendation-shelf.loading-items-per-page.desktop": "Desktop",
+  "admin/editor.recommendation-shelf.loading-items-per-page.tablet": "Tablet",
+  "admin/editor.recommendation-shelf.loading-items-per-page.phone": "Phone"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -9,5 +9,12 @@
   "admin/editor.recommendation-shelf.items-context.cart": "Carrito",
   "admin/editor.recommendation-shelf.items-context.pdp": "Página de producto",
   "admin/editor.recommendation-shelf.hidden-paths": "Rutas ocultas",
-  "admin/editor.recommendation-shelf.hidden-paths.description": "Rutas de URL donde la estantería no debe mostrarse. Use rutas exactas (p. ej. /checkout/cart) o comodines de prefijo con * (p. ej. /produto/*)."
+  "admin/editor.recommendation-shelf.hidden-paths.description": "Rutas de URL donde la estantería no debe mostrarse. Use rutas exactas (p. ej. /checkout/cart) o comodines de prefijo con * (p. ej. /produto/*).",
+  "admin/editor.recommendation-shelf.display-loading": "Mostrar carga",
+  "admin/editor.recommendation-shelf.display-loading.description": "Define si se debe mostrar un placeholder de carga mientras se carga la estantería.",
+  "admin/editor.recommendation-shelf.loading-items-per-page": "Elementos de carga por página",
+  "admin/editor.recommendation-shelf.loading-items-per-page.description": "El número de placeholders de carga a mostrar por tipo de dispositivo durante la carga.",
+  "admin/editor.recommendation-shelf.loading-items-per-page.desktop": "Escritorio",
+  "admin/editor.recommendation-shelf.loading-items-per-page.tablet": "Tableta",
+  "admin/editor.recommendation-shelf.loading-items-per-page.phone": "Teléfono"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -9,5 +9,12 @@
   "admin/editor.recommendation-shelf.items-context.cart": "Carrinho",
   "admin/editor.recommendation-shelf.items-context.pdp": "Página de Produto",
   "admin/editor.recommendation-shelf.hidden-paths": "Caminhos ocultos",
-  "admin/editor.recommendation-shelf.hidden-paths.description": "Caminhos de URL onde a vitrine não deve ser exibida. Use caminhos exatos (ex.: /checkout/cart) ou curingas de prefixo com * (ex.: /produto/*)."
+  "admin/editor.recommendation-shelf.hidden-paths.description": "Caminhos de URL onde a vitrine não deve ser exibida. Use caminhos exatos (ex.: /checkout/cart) ou curingas de prefixo com * (ex.: /produto/*).",
+  "admin/editor.recommendation-shelf.display-loading": "Exibir carregamento",
+  "admin/editor.recommendation-shelf.display-loading.description": "Define se um placeholder de carregamento deve ser exibido enquanto a vitrine é carregada.",
+  "admin/editor.recommendation-shelf.loading-items-per-page": "Itens de carregamento por página",
+  "admin/editor.recommendation-shelf.loading-items-per-page.description": "O número de placeholders de carregamento a exibir por tipo de dispositivo durante o carregamento.",
+  "admin/editor.recommendation-shelf.loading-items-per-page.desktop": "Desktop",
+  "admin/editor.recommendation-shelf.loading-items-per-page.tablet": "Tablet",
+  "admin/editor.recommendation-shelf.loading-items-per-page.phone": "Celular"
 }

--- a/react/RecommendationShelf.tsx
+++ b/react/RecommendationShelf.tsx
@@ -54,6 +54,36 @@ defineMessages({
     defaultMessage:
       'URL paths where the shelf should not be displayed. Use exact paths (e.g. /checkout/cart) or prefix wildcards with * (e.g. /produto/*).',
   },
+  displayLoading: {
+    id: 'admin/editor.recommendation-shelf.display-loading',
+    defaultMessage: 'Display loading',
+  },
+  displayLoadingDescription: {
+    id: 'admin/editor.recommendation-shelf.display-loading.description',
+    defaultMessage:
+      'Whether to display a loading placeholder while the shelf is loading.',
+  },
+  loadingItemsPerPage: {
+    id: 'admin/editor.recommendation-shelf.loading-items-per-page',
+    defaultMessage: 'Loading items per page',
+  },
+  loadingItemsPerPageDescription: {
+    id: 'admin/editor.recommendation-shelf.loading-items-per-page.description',
+    defaultMessage:
+      'The number of loading placeholders to display per device type while loading.',
+  },
+  loadingItemsPerPageDesktop: {
+    id: 'admin/editor.recommendation-shelf.loading-items-per-page.desktop',
+    defaultMessage: 'Desktop',
+  },
+  loadingItemsPerPageTablet: {
+    id: 'admin/editor.recommendation-shelf.loading-items-per-page.tablet',
+    defaultMessage: 'Tablet',
+  },
+  loadingItemsPerPagePhone: {
+    id: 'admin/editor.recommendation-shelf.loading-items-per-page.phone',
+    defaultMessage: 'Phone',
+  },
 })
 
 type Props = {
@@ -62,6 +92,8 @@ type Props = {
   displayTitle: boolean
   itemsContext: ItemContextType[]
   hiddenPaths?: string[]
+  displayLoading?: boolean
+  loadingItemsPerPage?: LoadingItemsPerPage
 }
 
 const RecommendationShelf: StorefrontFunctionComponent<Props> = ({
@@ -70,6 +102,8 @@ const RecommendationShelf: StorefrontFunctionComponent<Props> = ({
   displayTitle,
   itemsContext,
   hiddenPaths,
+  displayLoading,
+  loadingItemsPerPage,
 }) => {
   const { route } = useRuntime()
 
@@ -86,6 +120,8 @@ const RecommendationShelf: StorefrontFunctionComponent<Props> = ({
         title={title}
         displayTitle={displayTitle}
         itemsContext={itemsContext}
+        displayLoading={displayLoading}
+        loadingItemsPerPage={loadingItemsPerPage}
       />
     </RecommendationShelfErrorBoundary>
   )
@@ -132,6 +168,39 @@ RecommendationShelf.schema = {
         type: 'string',
       },
       default: [],
+    },
+    displayLoading: {
+      title: 'admin/editor.recommendation-shelf.display-loading',
+      description:
+        'admin/editor.recommendation-shelf.display-loading.description',
+      type: 'boolean',
+      default: true,
+    },
+    loadingItemsPerPage: {
+      title: 'admin/editor.recommendation-shelf.loading-items-per-page',
+      description:
+        'admin/editor.recommendation-shelf.loading-items-per-page.description',
+      type: 'object',
+      properties: {
+        desktop: {
+          title:
+            'admin/editor.recommendation-shelf.loading-items-per-page.desktop',
+          type: 'number',
+          default: 5,
+        },
+        tablet: {
+          title:
+            'admin/editor.recommendation-shelf.loading-items-per-page.tablet',
+          type: 'number',
+          default: 3,
+        },
+        phone: {
+          title:
+            'admin/editor.recommendation-shelf.loading-items-per-page.phone',
+          type: 'number',
+          default: 2,
+        },
+      },
     },
   },
 }

--- a/react/components/RecommendationShelfContainer.tsx
+++ b/react/components/RecommendationShelfContainer.tsx
@@ -16,6 +16,8 @@ type Props = {
   title?: string
   displayTitle: boolean
   itemsContext: ItemContextType[]
+  displayLoading?: boolean
+  loadingItemsPerPage?: LoadingItemsPerPage
 }
 
 export const RecommendationShelfContainer: React.FC<Props> = ({
@@ -23,6 +25,8 @@ export const RecommendationShelfContainer: React.FC<Props> = ({
   title,
   displayTitle,
   itemsContext = ['PDP'],
+  displayLoading = true,
+  loadingItemsPerPage,
 }) => {
   const productContext = useProduct()
   const {
@@ -116,7 +120,11 @@ export const RecommendationShelfContainer: React.FC<Props> = ({
   }, [data, error])
 
   if (loading || userId === undefined) {
-    return <ShelfSkeleton />
+    return displayLoading ? (
+      <ShelfSkeleton itemsPerPage={loadingItemsPerPage} />
+    ) : (
+      <Fragment />
+    )
   }
 
   if (campaignVrn && !isValidVrn(campaignVrn)) {

--- a/react/components/RecommendationShelfContainer.tsx
+++ b/react/components/RecommendationShelfContainer.tsx
@@ -45,6 +45,37 @@ export const RecommendationShelfContainer: React.FC<Props> = ({
     }
   }, [])
 
+  // The pixel might take a while to load and set the userId cookie,
+  // so we use a retry mechanism to ensure we get the userId if available.
+  useEffect(() => {
+    if (!canUseDOM) {
+      return undefined
+    }
+
+    let isMounted = true
+
+    getWithRetry<string>(() => getUserIdFromCookie())
+      .then((value) => {
+        if (isMounted) {
+          setUserId(value)
+        }
+      })
+      .catch((error) => {
+        if (isMounted) {
+          logger.error({
+            message: 'Error retrieving userId from cookie',
+            data: { error, campaignType },
+            sendLog: true,
+          })
+          setUserId(null)
+        }
+      })
+
+    return () => {
+      isMounted = false
+    }
+  }, [campaignType])
+
   const cartItems: string[] =
     orderFormItems?.map((item: { productId: string }) => item.productId) ?? []
 
@@ -63,29 +94,6 @@ export const RecommendationShelfContainer: React.FC<Props> = ({
 
   // Remove duplicates and falsy values
   productIds = Array.from(new Set(productIds)).filter(Boolean)
-
-  if (canUseDOM && !userId && userId !== null) {
-    // The pixel might take a while to load and set the userId cookie,
-    // so we use a retry mechanism to ensure we get the userId if available.
-    getWithRetry<string>(() => {
-      if (canUseDOM && !userId) {
-        return getUserIdFromCookie()
-      }
-
-      return ''
-    })
-      .then((value) => {
-        setUserId(value)
-      })
-      .catch((error) => {
-        logger.error({
-          message: 'Error retrieving userId from cookie',
-          data: { error, campaignType },
-          sendLog: true,
-        })
-        setUserId(null)
-      })
-  }
 
   const { data, error, loading } = useRecommendations({
     userId,

--- a/react/components/ShelfSkeleton/index.tsx
+++ b/react/components/ShelfSkeleton/index.tsx
@@ -6,26 +6,35 @@ import { SkeletonPiece } from './SkeletonPiece'
 
 const CSS_HANDLES = ['recommendationShelfContainer']
 
-// Number of skeleton tiles per device type. The device is resolved by
+// Default number of skeleton tiles per device type. The device is resolved by
 // render-runtime from the User-Agent on the server, so it is consistent
 // across SSR and client hydration (unlike window.innerWidth).
-const DEVICE_MAP = {
+const DEFAULT_ITEMS_PER_PAGE: Required<LoadingItemsPerPage> = {
   phone: 2,
   tablet: 3,
   desktop: 5,
-} as const
+}
 
-export function ShelfSkeleton() {
+type Props = {
+  itemsPerPage?: LoadingItemsPerPage
+}
+
+export function ShelfSkeleton({ itemsPerPage }: Props) {
   const handles = useCssHandles(CSS_HANDLES)
   const { deviceInfo } = useRuntime()
 
-  const skeletonCount =
-    DEVICE_MAP[deviceInfo?.type as keyof typeof DEVICE_MAP] ??
-    DEVICE_MAP.desktop
+  const deviceType =
+    (deviceInfo?.type as keyof LoadingItemsPerPage) ?? 'desktop'
 
-  const skeletonPieces = Array.from({ length: skeletonCount }, (_, index) => (
-    <SkeletonPiece key={index} />
-  ))
+  const skeletonCount =
+    itemsPerPage?.[deviceType] ??
+    DEFAULT_ITEMS_PER_PAGE[deviceType] ??
+    DEFAULT_ITEMS_PER_PAGE.desktop
+
+  const skeletonPieces = Array.from(
+    { length: Math.max(0, skeletonCount) },
+    (_, index) => <SkeletonPiece key={index} />
+  )
 
   return (
     <div

--- a/react/hooks/useRecommendations.tsx
+++ b/react/hooks/useRecommendations.tsx
@@ -18,7 +18,13 @@ function getRecommendationArguments(
   input: RecommendationInput,
   account: string
 ): Args | null {
-  const { userId, products, campaignVrn } = input
+  const { userId, campaignVrn } = input
+
+  // Sort and de-duplicate the products so the generated args are stable
+  // regardless of the input order, improving cache hits and consistency.
+  const products = Array.from(new Set(input.products)).sort((a, b) =>
+    a.localeCompare(b)
+  )
 
   const recommendationType = getTypeFromVrn(campaignVrn)
 

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -25,4 +25,10 @@ declare global {
     | 'NEXT_INTERACTION'
 
   export type ItemContextType = 'PDP' | 'CART'
+
+  export type LoadingItemsPerPage = {
+    desktop?: number
+    tablet?: number
+    phone?: number
+  }
 }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -39,6 +39,34 @@
             "title": "admin/editor.recommendation-shelf.hidden-paths",
             "$ref": "app:vtex.native-types#/definitions/text"
           }
+        },
+        "displayLoading": {
+          "title": "admin/editor.recommendation-shelf.display-loading",
+          "description": "admin/editor.recommendation-shelf.display-loading.description",
+          "type": "boolean",
+          "default": true
+        },
+        "loadingItemsPerPage": {
+          "title": "admin/editor.recommendation-shelf.loading-items-per-page",
+          "description": "admin/editor.recommendation-shelf.loading-items-per-page.description",
+          "type": "object",
+          "properties": {
+            "desktop": {
+              "title": "admin/editor.recommendation-shelf.loading-items-per-page.desktop",
+              "type": "number",
+              "default": 5
+            },
+            "tablet": {
+              "title": "admin/editor.recommendation-shelf.loading-items-per-page.tablet",
+              "type": "number",
+              "default": 3
+            },
+            "phone": {
+              "title": "admin/editor.recommendation-shelf.loading-items-per-page.phone",
+              "type": "number",
+              "default": 2
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- Add `displayLoading` prop (default `true`) to toggle whether the loading placeholder is rendered while the shelf loads.
- Add `loadingItemsPerPage` responsive object prop (`{ desktop, tablet, phone }`) to customize the number of loading placeholders per device type, replacing the previously hardcoded device map (mirrors `itemsPerPage` from `slider-layout`).
- Sort and de-duplicate the products in `getRecommendationArguments` before generating the request args, so args are stable regardless of input order (better cache hits and consistency).
- Update admin/Site Editor schemas, i18n messages (en/pt/es/context), docs, and changelog accordingly.

## Notes

- The public `recommendationSkeletonPiece` CSS handle and internal `ShelfSkeleton`/`SkeletonPiece` components are intentionally left unchanged to avoid breaking existing store customizations.
- For single-product strategies (`SIMILAR_ITEMS`, `VISUAL_SIMILARITY`, `NEXT_INTERACTION`), the picked product is now the first from the sorted, deduped list.

## Test plan

- [ ] Verify the shelf renders the correct number of loading placeholders per device (desktop/tablet/phone) using `loadingItemsPerPage`.
- [ ] Verify `displayLoading: false` renders nothing while loading.
- [ ] Verify defaults preserve prior behavior when no new props are set.
- [ ] Verify recommendation requests produce identical args for the same set of products in different orders.

Made with [Cursor](https://cursor.com)