### PR TITLE
feat: add loading-specific CSS handle to shelf skeleton container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `recommendationShelfContainerLoading` CSS handle to the shelf skeleton container so the loading state can be styled independently.
+
 ## [2.23.1] - 2026-08-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.24.0] - 2026-08-10
+
 ### Added
 
 - `recommendationShelfContainerLoading` CSS handle to the shelf skeleton container so the loading state can be styled independently.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "recommendation-shelf",
   "vendor": "vtex",
-  "version": "2.23.1",
+  "version": "2.24.0",
   "title": "Recommendation Shelf Components",
   "description": "Recommendation components and functionality for VTEX IO.",
   "builders": {

--- a/react/components/ShelfSkeleton/index.tsx
+++ b/react/components/ShelfSkeleton/index.tsx
@@ -4,7 +4,10 @@ import { useRuntime } from 'vtex.render-runtime'
 
 import { SkeletonPiece } from './SkeletonPiece'
 
-const CSS_HANDLES = ['recommendationShelfContainer']
+const CSS_HANDLES = [
+  'recommendationShelfContainer',
+  'recommendationShelfContainerLoading',
+]
 
 // Default number of skeleton tiles per device type. The device is resolved by
 // render-runtime from the User-Agent on the server, so it is consistent
@@ -38,7 +41,7 @@ export function ShelfSkeleton({ itemsPerPage }: Props) {
 
   return (
     <div
-      className={`${handles.recommendationShelfContainer} w-100 flex justify-center`}
+      className={`${handles.recommendationShelfContainer} ${handles.recommendationShelfContainerLoading} w-100 flex justify-center`}
     >
       {skeletonPieces}
     </div>


### PR DESCRIPTION
## Summary

- Add the `recommendationShelfContainerLoading` CSS handle to the shelf skeleton container (`ShelfSkeleton`), applied alongside the existing `recommendationShelfContainer` handle.
- This lets stores target and style the shelf's loading placeholder independently from the loaded state.
- Update the changelog under `[Unreleased]`.

## Test plan

- [ ] Verify the skeleton renders while the shelf loads and both `recommendationShelfContainer` and `recommendationShelfContainerLoading` handles are present on the container.
- [ ] Confirm custom CSS targeting `recommendationShelfContainerLoading` applies only during the loading state.

Made with [Cursor](https://cursor.com)